### PR TITLE
当请求正文内容过大遇到`HTTP/1.1 100 Continue`的解决办法

### DIFF
--- a/src/Queue/Driver/CMQHttp.php
+++ b/src/Queue/Driver/CMQHttp.php
@@ -65,6 +65,7 @@ class CMQHttp
         curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->connection_timeout + $userTimeout);
 
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($this->curl, CURLOPT_HTTPHEADER, array( 'Expect:' ) );
 
         if (false !== strpos($url, "https")) {
             // 证书


### PR DESCRIPTION
在实际使用中会遇到有一些队列发不出去，显示超时。经过抓包发现是因为包比较大，腾讯服务器返回了
```
HTTP/1.1 100 Continue
```

在[stackoverflow](https://stackoverflow.com/questions/11359276/php-curl-exec-returns-both-http-1-1-100-continue-and-http-1-1-200-ok-separated-b)上搜索了以下，发现可以增加以下语句解决：
```
curl_setopt($this->curl, CURLOPT_HTTPHEADER, array( 'Expect:' ) );
```

